### PR TITLE
isOnCorner() in flippy.py only checks the upperleft corner.

### DIFF
--- a/static/flippy.py
+++ b/static/flippy.py
@@ -475,11 +475,8 @@ def makeMove(board, tile, xstart, ystart, realMove=False):
 
 
 def isOnCorner(x, y):
-    # Returns True if the position is in one of the four corners.
-    return (x == 0 and y == 0) or \
-           (x == BOARDWIDTH and y == 0) or \
-           (x == 0 and y == BOARDHEIGHT) or \
-           (x == BOARDWIDTH and y == BOARDHEIGHT)
+    # Return True if the position is in one of the four corners.
+    return (x == 0 or x == BOARDWIDTH - 1) and (y == 0 or y == BOARDHEIGHT - 1)
 
 
 def getComputerMove(board, computerTile):


### PR DESCRIPTION
x is never equal to BOARDWIDTH and y is never equal to BOARDHEIGHT.

I used the version in Invent Your Own Computer Games with Python, 4th Edition, Chapter 15 - The Reversegam Game as the fix.